### PR TITLE
hotfix(packages): koa-joi-router version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "koa": "^1.1.2",
-    "koa-joi-router": "^4.0.0",
+    "koa-joi-router": "git+https://github.com/sahal/joi-router.git#support/4.0.0",
     "node-dev": "^3.1.1"
   }
 }


### PR DESCRIPTION
This fixes #10

Since we can't use version 5 of koa-joi-router yet, [they provide here](https://github.com/koajs/joi-router/issues/39) a temporary fix.
This is not final, we need to update to version 5.