### PR TITLE
feat(components/route-params): schema for any.when type

### DIFF
--- a/src/components/route-params.js
+++ b/src/components/route-params.js
@@ -140,7 +140,11 @@ function paramsRow (schema, field) {
   let type = schema._type;
   if(type === 'alternatives') {
     const schemas = get(schema, '_inner.matches', []);
-    type = schemas.map(s => s.schema._type).join(' | ');
+    type = schemas.map(s => {
+      if (s.schema)
+        return s.schema._type;
+      return whenLabel(s);
+    }).join(' | ');
   }
   return m('tr', [
     m('td', field + (flags.default !== undefined ? ` = ${flags.default}` : '')),
@@ -180,4 +184,8 @@ function arrayLabel (schema) {
   if (!isArray(schema)) return '';
   const items = getItems(schema).map(itemLabel);
   return `Array [ ${items} ]`;
+}
+
+function whenLabel (schema) {
+  return `(when ${schema.ref.key} is ${schema.is._valids._set}) then ${itemLabel(schema.then)}`;
 }


### PR DESCRIPTION
Fixes #11 
Now, when you use the [any.when](https://github.com/hapijs/joi/blob/v10.5.2/API.md#anywhenref-options), the documentation will recognize